### PR TITLE
Pull request for adding a ScriptRelease variable with it being displayed in the console.

### DIFF
--- a/GBA-PK_Client.lua
+++ b/GBA-PK_Client.lua
@@ -10,6 +10,7 @@ local GameCode = "None"
 local ConfirmPackett = 0
 local EnableScript = false
 local ClientConnection
+local ScriptRelease = "ALPHA 3"
 
 local u32 SpriteTempVar0 = 0
 local u32 SpriteTempVar1 = 0
@@ -21688,8 +21689,10 @@ console:log("Started GBA-PK_Client.lua")
 if not (emu == nil) then
 	if ConsoleForText == nil then ConsoleForText = console:createBuffer("GBA-PK CLIENT") end
 	ConsoleForText:clear()
-	ConsoleForText:moveCursor(0,1)
+	ConsoleForText:moveCursor(0,0)
 	FFTimer2 = os.time()
+	ConsoleForText:print("Release Version: "..ScriptRelease)
+	ConsoleForText:moveCursor(0,1)
     GetGameVersion()
 end
 

--- a/GBA-PK_Server.lua
+++ b/GBA-PK_Server.lua
@@ -10,6 +10,7 @@ local GameCode = "None"
 local ConfirmPackett = 0
 local EnableScript = false
 local ClientConnection
+local ScriptRelease = "ALPHA 3"
 
 local u32 SpriteTempVar0 = 0
 local u32 SpriteTempVar1 = 0
@@ -21798,8 +21799,10 @@ console:log("Started GBA-PK_Server.lua")
 if not (emu == nil) then
 	if ConsoleForText == nil then ConsoleForText = console:createBuffer("GBA-PK SERVER") end
 	ConsoleForText:clear()
-	ConsoleForText:moveCursor(0,1)
+	ConsoleForText:moveCursor(0,0)
 	FFTimer2 = os.time()
+	ConsoleForText:print("Release Version: "..ScriptRelease)
+	ConsoleForText:moveCursor(0,1)
     GetGameVersion()
 end
 


### PR DESCRIPTION
After looking through the code for a while, (it's insane! I praise your effort,) I decided to not bother about warning the user about the client/host having a different version and work on that some other time. I can already tell I don't have as much experience with sockets as you have. **This pull request is meant to help users tell what version their script is to <ins>avoid the problems of connecting to a user with an outdated release</ins>, which has already happened (refer to #22 .)**

I got ahold of how the script was working together, (it's a lot to take in,) but then I couldn't figure out what to change without breaking anything.
```lua
--Send Data to clients
function CreatePackett(RequestTemp, PackettTemp)
	local FillerStuff = "F"
	Packett = GameID .. Nickname .. PlayerID2 .. PlayerReceiveID .. RequestTemp .. PackettTemp .. CurrentX[PlayerID] .. CurrentY[PlayerID] .. Facing2[PlayerID] .. PlayerExtra1[PlayerID] .. PlayerExtra2[PlayerID] .. PlayerExtra3[PlayerID] .. PlayerExtra4[PlayerID] .. PlayerMapID .. PlayerMapIDPrev .. PlayerMapEntranceType .. StartX[PlayerID] .. StartY[PlayerID] .. FillerStuff .. "U"
end
```
Sadly I didn't have anyone to test my changes with remotely at the time, and I was trying to use my existing knowledge to include the release version of what script the user was using inside the packet being sent. Problem is, while I have Lua experience, I've mostly done this kind of stuff using python. This would be a handy feature to have in the next fix, just to make sure we don't get people confused. Because well, we already have enough people confused and lots of unclosed issues. Maybe you can do it before I can, edits are allowed for people with write access to the main branch.

If this is good, please review! (And merge, if you are the repo owner, yes, I see you)